### PR TITLE
Fix webapp build and routing issues

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -74,9 +74,7 @@ function App() {
         ) : (
           <Route index element={<LoginPage />} />
         )}
-        <Route path="*">
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>
   );

--- a/packages/webapp/src/components/ImportCompetitionDialog.tsx
+++ b/packages/webapp/src/components/ImportCompetitionDialog.tsx
@@ -26,7 +26,11 @@ import { gql, useMutation } from '@apollo/client';
 import { ImportCompetitionMutation } from '../graphql';
 import { useSnackbar } from 'notistack';
 
-const FlagIcon = FlagIconFactory(React, { useCssModules: false });
+const RawFlagIcon = FlagIconFactory(React, { useCssModules: false });
+const FlagIcon = RawFlagIcon as React.ComponentType<{
+  code: string;
+  size?: string;
+}>;
 
 const Transition = forwardRef(function Transition(
   props: TransitionProps & {

--- a/packages/webapp/src/containers/CompetitionList/CompetitionList.tsx
+++ b/packages/webapp/src/containers/CompetitionList/CompetitionList.tsx
@@ -36,7 +36,7 @@ export function CompetitionList() {
           })
           .sort(
             (a, b) =>
-              new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+              new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
           )
       : [];
   }, [data]);

--- a/packages/webapp/src/pages/Competition/Layout.tsx
+++ b/packages/webapp/src/pages/Competition/Layout.tsx
@@ -36,16 +36,16 @@ function CompetitionLayout() {
   const [_, setAppTitle] = useContext(StoreContext).appTitle;
   const { competitionId } = useParams<{ competitionId: string }>();
   const { isLoading, data: wcif } = useReactQuery<Competition>({
-    queryKey: ['public'],
-    queryFn: () =>
-      wcaApiFetch(`/api/v0/competitions/${competitionId || ''}/wcif`),
+    queryKey: ['competition-wcif', competitionId],
+    enabled: Boolean(competitionId),
+    queryFn: () => wcaApiFetch(`/api/v0/competitions/${competitionId}/wcif`),
   });
 
   useEffect(() => {
     if (wcif && wcif?.id !== competitionId) {
       navigate(`/competitions/${wcif?.id}`, { replace: true });
     }
-  }, [competitionId, wcif]);
+  }, [competitionId, navigate, wcif]);
 
   const {
     data: currentActivities,
@@ -85,11 +85,11 @@ function CompetitionLayout() {
     });
 
     return () => unsub();
-  }, [wcif]);
+  }, [subscribeToMore, wcif?.id]);
 
   useEffect(() => {
     setAppTitle(wcif?.name || 'Competition Schedule Live');
-  }, [wcif?.name]);
+  }, [setAppTitle, wcif?.name]);
 
   const ongoingActivities = currentActivities?.activities?.filter(
     (activity) => activity.startTime && !activity.endTime

--- a/packages/webapp/src/pages/Login.tsx
+++ b/packages/webapp/src/pages/Login.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material';
 import { useAuth } from '../providers/AuthProvider';
 
 function LoginPage() {
-  const { login, jwt } = useAuth();
+  const { login } = useAuth();
 
   return (
     <div
@@ -13,7 +13,6 @@ function LoginPage() {
         alignItems: 'center',
         justifyContent: 'center',
       }}>
-      {jwt}
       <Button onClick={login}>Login</Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix the webapp TypeScript build break caused by the flag icon component typing
- fix competition WCIF caching so navigation between competitions fetches the correct data
- remove the JWT leak on the login page and clean up a couple of webapp routing/list issues

## Testing
- env COREPACK_HOME=/tmp/corepack yarn build:webapp