### PR TITLE
Fix follow-up webapp UI bugs

### DIFF
--- a/packages/webapp/src/components/CompetitionStatusBar.tsx
+++ b/packages/webapp/src/components/CompetitionStatusBar.tsx
@@ -172,7 +172,7 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
 
   const advanceToNextActivities = useCallback(async () => {
     // figure out what activities are currently going on
-    if (!Object.keys(ongoingActivitiesByCode) || !nextActivity) {
+    if (!Object.keys(ongoingActivitiesByCode).length || !nextActivity) {
       return;
     }
 
@@ -197,7 +197,7 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
               const room = getRoomForActivity(activityData);
 
               return (
-                <ListItem>
+                <ListItem key={activity.activityId}>
                   <ListItemText
                     primary={activityData?.name}
                     secondary={room?.name ?? '???'}
@@ -216,7 +216,7 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
               const room = getRoomForActivity(activityData);
 
               return (
-                <ListItem>
+                <ListItem key={activityData.id}>
                   <ListItemText
                     primary={activityData.name}
                     secondary={room?.name ?? '???'}
@@ -234,10 +234,10 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
       variables: {
         competitionId: wcif?.id,
         stopActivityIds: ongoingActivities?.map((a) => a.activityId),
-        startActivityIds: starting.map((a) => a.id),
+        startActivityIds: starting?.map((a) => a.id) ?? [],
       },
     });
-  }, [wcif, nextActivity, ongoingActivities]);
+  }, [activities, allChildActivities, confirm, getRoomForActivity, nextActivity, ongoingActivities, ongoingActivitiesByCode, stopAndStartActivities, wcif?.id]);
 
   const startOrStopActivities = async ({
     activityCode,
@@ -313,7 +313,7 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
               const room = getRoomForActivity(activityData);
 
               return (
-                <ListItem>
+                <ListItem key={activity.activityId}>
                   <ListItemText
                     primary={activityData?.name}
                     secondary={room?.name ?? '???'}
@@ -499,7 +499,7 @@ export function CompetitionStatusBar({}: CompetitionStatusBarProps) {
           variant="contained"
           onClick={stopongoingActivities}
           disabled={!ongoingActivities?.length}>
-          Stop Current {pluralize('activity', allChildActivities?.length || 0)}
+          Stop Current {pluralize('activity', ongoingActivities?.length || 0)}
         </Button>
       </ButtonGroup>
     </Paper>

--- a/packages/webapp/src/components/Mainbar.tsx
+++ b/packages/webapp/src/components/Mainbar.tsx
@@ -68,13 +68,13 @@ function Mainbar() {
           </Box>
 
           <Box sx={{ flexGrow: 0 }}>
-            <Tooltip title="Open user menu">
-              <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                <Avatar alt={user?.name} src={user?.avatar?.thumb_url} />
-              </IconButton>
-            </Tooltip>
             {user && (
               <>
+                <Tooltip title="Open user menu">
+                  <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+                    <Avatar alt={user?.name} src={user?.avatar?.thumb_url} />
+                  </IconButton>
+                </Tooltip>
                 <Menu
                   sx={{ mt: '45px' }}
                   id="menu-appbar-user"

--- a/packages/webapp/src/pages/Competition/Room.tsx
+++ b/packages/webapp/src/pages/Competition/Room.tsx
@@ -34,6 +34,14 @@ import { allChildActivities } from '@notifycomp/frontend-common/lib';
 const durationToMinutes = (start: Date, end: Date): number =>
   Math.round((end.getTime() - start.getTime()) / 1000 / 60);
 
+const formatScheduleDelta = (scheduledTime: string, actualTime: string) => {
+  const minutes = durationToMinutes(new Date(scheduledTime), new Date(actualTime));
+
+  return `Ended ${formatDuration({ minutes: Math.abs(minutes) })} ${
+    minutes < 0 ? 'early' : 'late'
+  }`;
+};
+
 // import red from '@mui/material/colors/red';
 // import yellow from '@mui/material/colors/yellow';
 
@@ -361,13 +369,10 @@ function CompetitionRoom() {
                   !!liveActivity?.startTime &&
                   !!liveActivity?.endTime
                 ) {
-                  const minutes = durationToMinutes(
-                    new Date(liveActivity.startTime),
-                    new Date(liveActivity.endTime)
+                  secondaryText = formatScheduleDelta(
+                    activity.endTime,
+                    liveActivity.endTime
                   );
-                  secondaryText = `Ended ${formatDuration({ minutes })} ${
-                    minutes < 0 ? 'early' : 'late'
-                  }`;
                 }
 
                 return (
@@ -406,11 +411,9 @@ function CompetitionRoom() {
                   !!liveActivity?.startTime &&
                   !!liveActivity?.endTime
                 ) {
-                  const minutesLate = Math.round(
-                    (new Date(activity.endTime).getTime() -
-                      new Date(liveActivity.startTime).getTime()) /
-                      1000 /
-                      60
+                  const minutesLate = durationToMinutes(
+                    new Date(activity.endTime),
+                    new Date(liveActivity.endTime)
                   );
                   const activityDuration = Math.round(
                     (new Date(liveActivity.endTime).getTime() -
@@ -419,8 +422,7 @@ function CompetitionRoom() {
                   );
                   secondaryText = (
                     <>
-                      Ended {formatDuration({ minutes: Math.abs(minutesLate) })}{' '}
-                      {minutesLate < 0 ? 'late' : 'early'}
+                      {formatScheduleDelta(activity.endTime, liveActivity.endTime)}
                       <br />
                       Ran for{' '}
                       {formatDuration({

--- a/packages/webapp/src/pages/Competition/Webhooks.tsx
+++ b/packages/webapp/src/pages/Competition/Webhooks.tsx
@@ -49,6 +49,7 @@ function CompetitionWebhooks() {
       <List>
         {webhooksData?.competition?.webhooks?.map((webhook) => (
           <ListItem
+            key={webhook.id}
             secondaryAction={
               <IconButton
                 edge="end"


### PR DESCRIPTION
## Summary
- fix room activity timing labels so early/late is computed from scheduled end vs actual end
- harden the competition status bar advance/stop UI and remove React list key warnings
- hide the empty user-menu trigger when no user is loaded and add missing webhook row keys

## Testing
- env COREPACK_HOME=/tmp/corepack yarn build:webapp