### PR TITLE
[codex] accept competitiongroups remote tokens

### DIFF
--- a/packages/server/auth/AuthMiddleware.ts
+++ b/packages/server/auth/AuthMiddleware.ts
@@ -1,7 +1,58 @@
 import fs from 'fs';
 import { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
+import {
+  CompetitionGroupsClaims,
+  verifyCompetitionGroupsToken,
+} from '../lib/competitionGroupsToken';
 const PUBLIC_KEY = process.env.PUBLIC_KEY ?? fs.readFileSync('public.key');
+const COMPETITION_GROUPS_REMOTE_SCOPE = 'notifycomp.remote';
+
+const scopesForClaims = (claims: CompetitionGroupsClaims) => [
+  ...(Array.isArray(claims.scope)
+    ? claims.scope
+    : claims.scope
+      ? [claims.scope]
+      : []),
+  ...(claims.scopes ?? []),
+];
+
+const competitionGroupsClaimsToUser = (
+  claims: CompetitionGroupsClaims
+): User => {
+  const scopes = scopesForClaims(claims);
+  if (!scopes.includes(COMPETITION_GROUPS_REMOTE_SCOPE)) {
+    throw new Error('CompetitionGroups token is not valid for remote control');
+  }
+
+  const id = claims.wcaUserId ?? claims.wcaUserIds[0];
+  if (!Number.isInteger(id)) {
+    throw new Error('CompetitionGroups token is missing a WCA user ID');
+  }
+
+  return {
+    type: 2,
+    id,
+    name: claims.name ?? claims.sub,
+    wcaId: '',
+    countryId: '',
+    avatar: {
+      url: '',
+    },
+    wca: {
+      accessToken: '',
+      expiration: 0,
+      refreshToken: '',
+      code: '',
+    },
+    competitionGroups: {
+      competitionIds: claims.competitionIds,
+      scopes,
+    },
+    iat: claims.iat ?? 0,
+    exp: claims.exp ?? 0,
+  };
+};
 
 export const authMiddlewareVerify = (
   req: Request,
@@ -24,17 +75,17 @@ export const authMiddlewareVerify = (
   const token = split[1];
 
   try {
-    jwt.verify(token, PUBLIC_KEY, (err, decoded) => {
-      if (err) {
-        return next(err);
-      }
-
-      req.user = decoded as User | undefined;
-      next(null);
-    });
+    req.user = jwt.verify(token, PUBLIC_KEY) as User | undefined;
+    next(null);
   } catch (e) {
-    console.error(e);
-    next(e);
+    try {
+      const claims = verifyCompetitionGroupsToken(token);
+      req.competitionGroups = claims;
+      req.user = competitionGroupsClaimsToUser(claims);
+      next(null);
+    } catch {
+      next(e);
+    }
   }
 };
 export const authMiddlewareDecode = (

--- a/packages/server/graphql/resolvers/mutations/ActivityMutations.ts
+++ b/packages/server/graphql/resolvers/mutations/ActivityMutations.ts
@@ -17,6 +17,13 @@ const isAuthorized = async (
     return;
   }
 
+  if (
+    user.competitionGroups?.competitionIds &&
+    !user.competitionGroups.competitionIds.includes(competitionId)
+  ) {
+    throw new Error('Not Authorized');
+  }
+
   const compAccess = await db.competitionAccess.findFirst({
     where: {
       competitionId: {
@@ -34,7 +41,7 @@ const isAuthorized = async (
 
 export const startActivity: MutationResolvers<AppContext>['startActivity'] =
   async (_, { competitionId, activityId }, { db, user, wcaApi }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     const activity = activitiesController.startActivity(
       competitionId,
@@ -58,12 +65,10 @@ export const startActivity: MutationResolvers<AppContext>['startActivity'] =
         'webhooks'
       );
       res
-        .filter(
-          (r): r is PromiseRejectedResult => r.status === 'rejected'
-        )
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
         .forEach((r) => {
-        console.log(competitionId, 'WEBHOOK REJECTED', r.reason);
-      });
+          console.log(competitionId, 'WEBHOOK REJECTED', r.reason);
+        });
     });
 
     return activity;
@@ -71,7 +76,7 @@ export const startActivity: MutationResolvers<AppContext>['startActivity'] =
 
 export const startActivities: MutationResolvers<AppContext>['startActivities'] =
   async (_, { competitionId, activityIds }, { db, user, wcaApi }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     const activities = await Promise.all(
       activityIds.map(async (activityId) =>
@@ -96,12 +101,10 @@ export const startActivities: MutationResolvers<AppContext>['startActivities'] =
         'webhooks'
       );
       res
-        .filter(
-          (r): r is PromiseRejectedResult => r.status === 'rejected'
-        )
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
         .forEach((r) => {
-        console.log(competitionId, 'WEBHOOK REJECTED', r.reason);
-      });
+          console.log(competitionId, 'WEBHOOK REJECTED', r.reason);
+        });
     });
 
     return activities;
@@ -109,14 +112,14 @@ export const startActivities: MutationResolvers<AppContext>['startActivities'] =
 
 export const stopActivity: MutationResolvers<AppContext>['stopActivity'] =
   async (_, { competitionId, activityId }, { db, user }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     return activitiesController.stopActivity(competitionId, activityId);
   };
 
 export const stopActivities: MutationResolvers<AppContext>['stopActivities'] =
   async (_, { competitionId, activityIds }, { db, user, pubsub }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     const activities = await Promise.all(
       activityIds.map(async (activityId) => {
@@ -150,7 +153,7 @@ export const stopActivities: MutationResolvers<AppContext>['stopActivities'] =
 
 export const resetActivities: MutationResolvers<AppContext>['resetActivities'] =
   async (_, { competitionId, activityIds }, { db, user, pubsub }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     await db.activityHistory.updateMany({
       where: {
@@ -194,7 +197,7 @@ export const resetActivities: MutationResolvers<AppContext>['resetActivities'] =
 
 export const resetActivity: MutationResolvers<AppContext>['resetActivity'] =
   async (_, { competitionId, activityId }, { db, user, pubsub }) => {
-    void isAuthorized(db, competitionId, user);
+    await isAuthorized(db, competitionId, user);
 
     const activity = await db.activityHistory.update({
       where: {

--- a/packages/server/graphql/resolvers/mutations/CompetitionMutations.ts
+++ b/packages/server/graphql/resolvers/mutations/CompetitionMutations.ts
@@ -6,6 +6,41 @@ import {
 } from '../../../scheduler';
 import { fetchCompWithNoScheduledActivities } from '../../../scheduler/utils';
 
+const isAuthorized = async (
+  db: AppContext['db'],
+  competitionId: string,
+  user?: AppContext['user']
+) => {
+  if (!user) {
+    throw new Error('Not Authenticated');
+  }
+
+  if (user.id === 8184) {
+    return;
+  }
+
+  if (
+    user.competitionGroups?.competitionIds &&
+    !user.competitionGroups.competitionIds.includes(competitionId)
+  ) {
+    throw new Error('Not Authorized');
+  }
+
+  const compAccess = await db.competitionAccess.findFirst({
+    where: {
+      competitionId: {
+        equals: competitionId,
+        mode: 'insensitive',
+      },
+      userId: user.id,
+    },
+  });
+
+  if (!compAccess) {
+    throw new Error('Not Authorized');
+  }
+};
+
 export const importCompetition: MutationResolvers<AppContext>['importCompetition'] =
   async (_, { competitionId }, { db, wcaApi, user }) => {
     if (!user) {
@@ -53,9 +88,7 @@ export const importCompetition: MutationResolvers<AppContext>['importCompetition
 
 export const updateAutoAdvance: MutationResolvers<AppContext>['updateAutoAdvance'] =
   async (_, { competitionId, autoAdvance }, { db, user }) => {
-    if (!user) {
-      throw new Error('Not Authenticated');
-    }
+    await isAuthorized(db, competitionId, user);
 
     if (autoAdvance === false) {
       console.log('Cancelling all scheduled activities', competitionId);

--- a/packages/server/lib/competitionGroupsToken.ts
+++ b/packages/server/lib/competitionGroupsToken.ts
@@ -5,7 +5,13 @@ export interface CompetitionGroupsClaims {
   iss?: string;
   aud?: string | string[];
   exp?: number;
+  iat?: number;
   nbf?: number;
+  competitionIds?: string[];
+  name?: string;
+  scope?: string | string[];
+  scopes?: string[];
+  wcaUserId?: number;
   wcaUserIds: number[];
 }
 
@@ -26,7 +32,9 @@ const audienceMatches = (
     return false;
   }
 
-  return Array.isArray(actual) ? actual.includes(expected) : actual === expected;
+  return Array.isArray(actual)
+    ? actual.includes(expected)
+    : actual === expected;
 };
 
 export const verifyCompetitionGroupsToken = (

--- a/packages/server/types/models.d.ts
+++ b/packages/server/types/models.d.ts
@@ -17,6 +17,11 @@ interface User {
     code: string;
   };
 
+  competitionGroups?: {
+    competitionIds?: string[];
+    scopes: string[];
+  };
+
   iat: number;
   exp: number;
 }


### PR DESCRIPTION
## Summary

- Accept scoped CompetitionGroups external JWTs for NotifyComp Remote GraphQL auth while preserving the existing NotifyComp JWT path.
- Require the `notifycomp.remote` scope and bind remote tokens to their declared `competitionIds`.
- Await activity mutation authorization and add the same competition-access check to `updateAutoAdvance`.

## Validation

- `yarn workspace api typecheck`
- `yarn workspace api lint`
- commit hook lint for affected API packages